### PR TITLE
feat: add contract options and card selection polish

### DIFF
--- a/src/main/java/sample/PartieController.java
+++ b/src/main/java/sample/PartieController.java
@@ -114,7 +114,7 @@ public class PartieController {
     }
 
     public void initHand(ArrayList<String> ids, ArrayList<String> liens, ArrayList<String> colors) {
-        main.setHgap(-20);
+        main.setHgap(-80);
         main.setVgap(0);
         for (int i = 0; i < ids.size(); i++) {
             InputStream is = getClass().getResourceAsStream("/sample/img/" + liens.get(i));

--- a/src/main/java/sample/PartieController.java
+++ b/src/main/java/sample/PartieController.java
@@ -70,8 +70,6 @@ public class PartieController {
     @FXML
     private Label scoreRight;
     @FXML
-    private Label scoreSelf;
-    @FXML
     private AnchorPane root;
     @FXML
     private HBox teamScoreBox;
@@ -110,6 +108,15 @@ public class PartieController {
             main.prefWrapLengthProperty().bind(root.widthProperty());
             root.widthProperty().addListener((o, ov, nv) -> resizeAllCards());
             root.heightProperty().addListener((o, ov, nv) -> resizeAllCards());
+        }
+        if (attackScoreLabel != null) {
+            attackScoreLabel.setText("?");
+        }
+        if (defenseScoreLabel != null) {
+            defenseScoreLabel.setText("?");
+        }
+        if (teamScoreBox != null) {
+            teamScoreBox.setVisible(true);
         }
     }
 
@@ -377,7 +384,6 @@ public class PartieController {
         updateCurrentPlayerLabel(current);
         int myNum = Integer.parseInt(AccueilController.numJoueur);
         if (scores != null && playerNames != null && scores.size() == playerNames.size()) {
-            scoreSelf.setText(String.format("%.1f", scores.get(myNum - 1)));
             for (int i = 1; i <= 4; i++) {
                 int playerNum = ((myNum + i - 1) % 5) + 1;
                 opponentScoreLabels.get(i - 1).setText(String.format("%.1f", scores.get(playerNum - 1)));

--- a/src/main/java/sample/PartieController.java
+++ b/src/main/java/sample/PartieController.java
@@ -114,7 +114,7 @@ public class PartieController {
     }
 
     public void initHand(ArrayList<String> ids, ArrayList<String> liens, ArrayList<String> colors) {
-        main.setHgap(-80);
+        main.setHgap(-30);
         main.setVgap(0);
         for (int i = 0; i < ids.size(); i++) {
             InputStream is = getClass().getResourceAsStream("/sample/img/" + liens.get(i));
@@ -692,7 +692,6 @@ public class PartieController {
             cardRanks.put(pendingDogIds.get(j), extractRank(pendingDogLiens.get(j)));
             main.getChildren().add(handView);
         }
-        main.setHgap(-80);
         sortHand();
         boxChien.getChildren().clear();
         retrieveDog.setVisible(false);

--- a/src/main/java/sample/PartieController.java
+++ b/src/main/java/sample/PartieController.java
@@ -114,7 +114,7 @@ public class PartieController {
     }
 
     public void initHand(ArrayList<String> ids, ArrayList<String> liens, ArrayList<String> colors) {
-        main.setHgap(-30);
+        main.setHgap(-20);
         main.setVgap(0);
         for (int i = 0; i < ids.size(); i++) {
             InputStream is = getClass().getResourceAsStream("/sample/img/" + liens.get(i));

--- a/src/main/java/sample/PartieController.java
+++ b/src/main/java/sample/PartieController.java
@@ -298,7 +298,7 @@ public class PartieController {
         String takeFlag = (String) resp.get(1);
         int numPlayerTake = (int) resp.get(2);
         String contract = resp.size() > 3 ? (String) resp.get(3) : "";
-        contractBox.setVisible(false);
+        hideContractBox();
         if (takeFlag.equals("TAKE")) {
             takerNum = numPlayerTake;
             lastCurrentPlayer = numPlayerTake;
@@ -314,7 +314,7 @@ public class PartieController {
             updateCurrentPlayerLabel(current);
             if (current == Integer.parseInt(AccueilController.numJoueur)) {
                 statusLabel.setText("A votre tour !");
-                contractBox.setVisible(true);
+                showContractBox();
             } else {
                 String name = playerNames != null && current <= playerNames.size()
                         ? playerNames.get(current - 1)
@@ -357,6 +357,7 @@ public class PartieController {
         String couleur = resp.size() > 5 ? normalizeColor((String) resp.get(5)) : "";
         ArrayList<Double> scores = resp.size() > 6 ? (ArrayList<Double>) resp.get(6) : null;
         lastScores = scores;
+        boxTour.setVisible(true);
         boxTour.getChildren().clear();
         highestAtoutCenter = 0;
         for (int i = 0; i < idCartes.size(); i++) {
@@ -569,6 +570,16 @@ public class PartieController {
         defenseScoreLabel.setText(String.format("%.1f", defense));
     }
 
+    private void showContractBox() {
+        contractBox.setManaged(true);
+        contractBox.setVisible(true);
+    }
+
+    private void hideContractBox() {
+        contractBox.setVisible(false);
+        contractBox.setManaged(false);
+    }
+
     private void sendContract(String type) {
         ArrayList<Object> msg = new ArrayList<>();
         msg.add("CHIEN");
@@ -579,7 +590,7 @@ public class PartieController {
         } catch (IOException | ClassNotFoundException e) {
             e.printStackTrace();
         }
-        contractBox.setVisible(false);
+        hideContractBox();
     }
 
     @FXML
@@ -604,7 +615,7 @@ public class PartieController {
         } catch (IOException | ClassNotFoundException e) {
             e.printStackTrace();
         }
-        contractBox.setVisible(false);
+        hideContractBox();
     }
 
     public void take(int numPlayerTake) {

--- a/src/main/java/sample/PartieController.java
+++ b/src/main/java/sample/PartieController.java
@@ -295,26 +295,32 @@ public class PartieController {
 
     private void handleAnswerUpdate(List<Object> resp) {
         int current = (int) resp.get(0);
-        lastCurrentPlayer = current;
-        updateCurrentPlayerLabel(current);
         String takeFlag = (String) resp.get(1);
         int numPlayerTake = (int) resp.get(2);
+        String contract = resp.size() > 3 ? (String) resp.get(3) : "";
         contractBox.setVisible(false);
         if (takeFlag.equals("TAKE")) {
             takerNum = numPlayerTake;
+            lastCurrentPlayer = numPlayerTake;
+            updateCurrentPlayerLabel(numPlayerTake);
             String name = playerNames != null && numPlayerTake <= playerNames.size()
                     ? playerNames.get(numPlayerTake - 1)
                     : "Joueur " + numPlayerTake;
-            statusLabel.setText(name + " a pris le chien");
+            String contractDisplay = contract.toLowerCase().replace('_', ' ');
+            statusLabel.setText(name + " déclare une " + contractDisplay);
             take(numPlayerTake);
-        } else if (current == Integer.parseInt(AccueilController.numJoueur)) {
-            statusLabel.setText("A votre tour !");
-            contractBox.setVisible(true);
         } else {
-            String name = playerNames != null && current <= playerNames.size()
-                    ? playerNames.get(current - 1)
-                    : "Joueur " + current;
-            statusLabel.setText("Au tour de " + name);
+            lastCurrentPlayer = current;
+            updateCurrentPlayerLabel(current);
+            if (current == Integer.parseInt(AccueilController.numJoueur)) {
+                statusLabel.setText("A votre tour !");
+                contractBox.setVisible(true);
+            } else {
+                String name = playerNames != null && current <= playerNames.size()
+                        ? playerNames.get(current - 1)
+                        : "Joueur " + current;
+                statusLabel.setText("Au tour de " + name);
+            }
         }
     }
 

--- a/src/main/java/sample/PartieController.java
+++ b/src/main/java/sample/PartieController.java
@@ -327,6 +327,9 @@ public class PartieController {
     private void handleCallInfo(List<Object> resp) {
         calledKingColor = normalizeColor((String) resp.get(4));
         statusLabel.setText("Le Roi de " + resp.get(4) + " a été appelé !");
+        boxRois.setVisible(false);
+        boxRois.getChildren().clear();
+        boxChien.setVisible(true);
         boxChien.getChildren().clear();
         ArrayList<Integer> idCartes = (ArrayList<Integer>) resp.get(1);
         ArrayList<String> lienCartes = (ArrayList<String>) resp.get(2);
@@ -607,6 +610,9 @@ public class PartieController {
     public void take(int numPlayerTake) {
         if(numPlayerTake == Integer.parseInt(AccueilController.numJoueur)){
             carteCenter.setVisible(false);
+            boxChien.setVisible(false);
+            boxRois.setVisible(true);
+            boxRois.getChildren().clear();
             ArrayList<Object> rois = new ArrayList<>();
             rois.add("ROIS");
             rois.add(ConnexionController.idUser);
@@ -658,6 +664,7 @@ public class PartieController {
     }
     public void callKing(String idCarte) {
         boxRois.getChildren().clear();
+        boxRois.setVisible(false);
         boxRois.setSpacing(20);
         boxChien.setSpacing(20);
         ArrayList<Object> calls = new ArrayList<>();

--- a/src/main/java/sample/PartieController.java
+++ b/src/main/java/sample/PartieController.java
@@ -28,7 +28,15 @@ public class PartieController {
     @FXML
     private FlowPane main;
     @FXML
-    private Button take;
+    private VBox contractBox;
+    @FXML
+    private Button petite;
+    @FXML
+    private Button garde;
+    @FXML
+    private Button gardeContre;
+    @FXML
+    private Button gardeSans;
     @FXML
     private Button refuse;
     @FXML
@@ -106,7 +114,7 @@ public class PartieController {
     }
 
     public void initHand(ArrayList<String> ids, ArrayList<String> liens, ArrayList<String> colors) {
-        main.setHgap(-10);
+        main.setHgap(-80);
         main.setVgap(0);
         for (int i = 0; i < ids.size(); i++) {
             InputStream is = getClass().getResourceAsStream("/sample/img/" + liens.get(i));
@@ -288,8 +296,10 @@ public class PartieController {
     private void handleAnswerUpdate(List<Object> resp) {
         int current = (int) resp.get(0);
         lastCurrentPlayer = current;
+        updateCurrentPlayerLabel(current);
         String takeFlag = (String) resp.get(1);
         int numPlayerTake = (int) resp.get(2);
+        contractBox.setVisible(false);
         if (takeFlag.equals("TAKE")) {
             takerNum = numPlayerTake;
             String name = playerNames != null && numPlayerTake <= playerNames.size()
@@ -299,8 +309,7 @@ public class PartieController {
             take(numPlayerTake);
         } else if (current == Integer.parseInt(AccueilController.numJoueur)) {
             statusLabel.setText("A votre tour !");
-            take.setVisible(true);
-            refuse.setVisible(true);
+            contractBox.setVisible(true);
         } else {
             String name = playerNames != null && current <= playerNames.size()
                     ? playerNames.get(current - 1)
@@ -551,32 +560,42 @@ public class PartieController {
         defenseScoreLabel.setText(String.format("%.1f", defense));
     }
 
-    public void playWithDog() throws InterruptedException {
-        ArrayList<Object> chiens = new ArrayList<>();
-        chiens.add("CHIEN");
-        chiens.add(ConnexionController.idUser);
-
+    private void sendContract(String type) {
+        ArrayList<Object> msg = new ArrayList<>();
+        msg.add("CHIEN");
+        msg.add(type);
+        msg.add(ConnexionController.idUser);
         try {
-            ConnexionController.client.send(chiens);
+            ConnexionController.client.send(msg);
         } catch (IOException | ClassNotFoundException e) {
             e.printStackTrace();
         }
-        refuse.setVisible(false);
-        take.setVisible(false);
+        contractBox.setVisible(false);
     }
 
-    public void playWithoutDog() throws InterruptedException {
+    @FXML
+    public void choosePetite() { sendContract("PETITE"); }
+
+    @FXML
+    public void chooseGarde() { sendContract("GARDE"); }
+
+    @FXML
+    public void chooseGardeContre() { sendContract("GARDE_CONTRE"); }
+
+    @FXML
+    public void chooseGardeSans() { sendContract("GARDE_SANS"); }
+
+    @FXML
+    public void chooseRefuse() {
         ArrayList<Object> refuses = new ArrayList<>();
         refuses.add("REFUSE");
         refuses.add(ConnexionController.idUser);
-
         try {
             ConnexionController.client.send(refuses);
         } catch (IOException | ClassNotFoundException e) {
             e.printStackTrace();
         }
-        refuse.setVisible(false);
-        take.setVisible(false);
+        contractBox.setVisible(false);
     }
 
     public void take(int numPlayerTake) {
@@ -601,6 +620,16 @@ public class PartieController {
                     ImageView imageRoi = new ImageView(img);
                     applyCardSize(imageRoi);
                     int finalI = i;
+                    imageRoi.setOnMouseEntered(e -> {
+                        imageRoi.setScaleX(1.2);
+                        imageRoi.setScaleY(1.2);
+                        imageRoi.setCursor(Cursor.HAND);
+                    });
+                    imageRoi.setOnMouseExited(e -> {
+                        imageRoi.setScaleX(1);
+                        imageRoi.setScaleY(1);
+                        imageRoi.setCursor(Cursor.DEFAULT);
+                    });
                     imageRoi.addEventHandler(javafx.scene.input.MouseEvent.MOUSE_CLICKED, event -> {
                         callKing(idCartes.get(finalI));
                     });
@@ -657,6 +686,7 @@ public class PartieController {
             cardRanks.put(pendingDogIds.get(j), extractRank(pendingDogLiens.get(j)));
             main.getChildren().add(handView);
         }
+        main.setHgap(-80);
         sortHand();
         boxChien.getChildren().clear();
         retrieveDog.setVisible(false);
@@ -665,8 +695,33 @@ public class PartieController {
     }
 
     private void enableDogSelection() {
+        ColorAdjust gray = new ColorAdjust();
+        gray.setSaturation(-1);
+        gray.setBrightness(-0.3);
         for (int i = 0; i < main.getChildren().size(); i++) {
             ImageView imageCarte = (ImageView) main.getChildren().get(i);
+            String id = imageCarte.getId();
+            String color = cardColors.get(id);
+            int rank = cardRanks.getOrDefault(id, 0);
+            boolean isBout = "BOUT".equals(color);
+            boolean isKing = rank == 14 && !"ATOUT".equals(color);
+            if (isBout || isKing) {
+                imageCarte.setDisable(true);
+                imageCarte.setEffect(gray);
+                continue;
+            }
+            imageCarte.setOnMouseEntered(e -> {
+                imageCarte.setScaleX(1.2);
+                imageCarte.setScaleY(1.2);
+                imageCarte.setViewOrder(-1);
+                imageCarte.setCursor(Cursor.HAND);
+            });
+            imageCarte.setOnMouseExited(e -> {
+                imageCarte.setScaleX(1);
+                imageCarte.setScaleY(1);
+                imageCarte.setViewOrder(0);
+                imageCarte.setCursor(Cursor.DEFAULT);
+            });
             imageCarte.setOnMouseClicked((e) -> {
                 ArrayList<Object> addDogs = new ArrayList<>();
                 addDogs.add("ADDDOG");

--- a/src/main/java/server/ClientProcessor.java
+++ b/src/main/java/server/ClientProcessor.java
@@ -76,17 +76,19 @@ public class ClientProcessor implements Runnable {
         ResultSet rs = ps.executeQuery();
         rs.next();
         int nbJoueur = rs.getInt("nbJoueur") + 1;
-        String query2 = "SELECT num FROM joueur WHERE reponse NOT IN ('WAIT','REFUSE') AND partie = ?";
+        String query2 = "SELECT num, reponse FROM joueur WHERE reponse NOT IN ('WAIT','REFUSE') AND partie = ?";
         PreparedStatement ps2 = this.connection.prepareStatement(query2);
         ps2.setInt(1, currentPartie);
         ResultSet rs2 = ps2.executeQuery();
         String flag = "NOTAKE";
         int numPlayer = -1;
+        String contract = "";
         if (rs2.next()) {
             flag = "TAKE";
             numPlayer = rs2.getInt("num");
+            contract = rs2.getString("reponse");
         }
-        broadcast(List.of("ANSWER_UPDATE", nbJoueur, flag, numPlayer));
+        broadcast(List.of("ANSWER_UPDATE", nbJoueur, flag, numPlayer, contract));
     }
 
     private void broadcastCallInfo(ArrayList<Integer> ids, ArrayList<String> liens, ArrayList<String> couleurs, String couleur) {
@@ -480,33 +482,35 @@ public class ClientProcessor implements Runnable {
                     toSend.add(noms);
 
                 } else if(responses.get(0).toString().toUpperCase().equals("WAITANSWER")) {
-                    String query = "SELECT COUNT(id) AS\"nbJoueur\"  FROM joueur WHERE reponse != 'WAIT' AND partie = "+ currentPartie;
+                    String query = "SELECT COUNT(id) AS\"nbJoueur\"  FROM joueur WHERE reponse != 'WAIT' AND partie = " + currentPartie;
                     PreparedStatement ps = this.connection.prepareStatement(query);
                     ResultSet results = ps.executeQuery();
                     results.next();
-                    int nbJoueur = results.getInt("nbJoueur")+1;
+                    int nbJoueur = results.getInt("nbJoueur") + 1;
 
-                    String query2 = "SELECT num FROM joueur WHERE reponse NOT IN ('WAIT','REFUSE') AND partie = ?";
+                    String query2 = "SELECT num, reponse FROM joueur WHERE reponse NOT IN ('WAIT','REFUSE') AND partie = ?";
                     PreparedStatement ps2 = this.connection.prepareStatement(query2);
                     ps2.setInt(1, currentPartie);
                     ResultSet results2 = ps2.executeQuery();
                     int hasTake = 0;
                     int numPlayer = -1;
-                    if(results2.next()) {
+                    String contract = "";
+                    if (results2.next()) {
                         hasTake = 1;
                         numPlayer = results2.getInt("num");
+                        contract = results2.getString("reponse");
                     }
 
                     toSend.add(nbJoueur);
-                    if(hasTake >0) {
+                    if (hasTake > 0) {
                         toSend.add("TAKE");
                         toSend.add(numPlayer);
+                        toSend.add(contract);
                     } else {
                         toSend.add("NOTAKE");
                         toSend.add(-1);
+                        toSend.add("");
                     }
-
-
 
                 }
                 else if(responses.get(0).toString().toUpperCase().equals("CHIEN")) {

--- a/src/main/java/server/ClientProcessor.java
+++ b/src/main/java/server/ClientProcessor.java
@@ -76,7 +76,7 @@ public class ClientProcessor implements Runnable {
         ResultSet rs = ps.executeQuery();
         rs.next();
         int nbJoueur = rs.getInt("nbJoueur") + 1;
-        String query2 = "SELECT num FROM joueur WHERE reponse = 'TAKE' AND partie = ?";
+        String query2 = "SELECT num FROM joueur WHERE reponse NOT IN ('WAIT','REFUSE') AND partie = ?";
         PreparedStatement ps2 = this.connection.prepareStatement(query2);
         ps2.setInt(1, currentPartie);
         ResultSet rs2 = ps2.executeQuery();
@@ -99,7 +99,7 @@ public class ClientProcessor implements Runnable {
 
     private void broadcastTourUpdate() throws SQLException {
         if(currentJoueurTour == -1) {
-            String query = "SELECT num FROM joueur WHERE reponse = 'TAKE' AND partie = ?";
+            String query = "SELECT num FROM joueur WHERE reponse NOT IN ('WAIT','REFUSE') AND partie = ?";
             PreparedStatement ps = this.connection.prepareStatement(query);
             ps.setInt(1, currentPartie);
             ResultSet results = ps.executeQuery();
@@ -486,7 +486,7 @@ public class ClientProcessor implements Runnable {
                     results.next();
                     int nbJoueur = results.getInt("nbJoueur")+1;
 
-                    String query2 = "SELECT num FROM joueur WHERE reponse = 'TAKE' AND partie = ?";
+                    String query2 = "SELECT num FROM joueur WHERE reponse NOT IN ('WAIT','REFUSE') AND partie = ?";
                     PreparedStatement ps2 = this.connection.prepareStatement(query2);
                     ps2.setInt(1, currentPartie);
                     ResultSet results2 = ps2.executeQuery();
@@ -510,13 +510,13 @@ public class ClientProcessor implements Runnable {
 
                 }
                 else if(responses.get(0).toString().toUpperCase().equals("CHIEN")) {
-                    String idUser = (String) responses.get(1);
+                    String contract = (String) responses.get(1);
+                    String idUser = (String) responses.get(2);
 
                     Statement stmt2 = this.connection.createStatement();
-                    stmt2.executeUpdate("UPDATE joueur SET reponse = 'TAKE' , equipe = 1 WHERE utilisateur = " + idUser + " AND partie = " + currentPartie) ;
+                    stmt2.executeUpdate("UPDATE joueur SET reponse = '" + contract + "' , equipe = 1 WHERE utilisateur = " + idUser + " AND partie = " + currentPartie);
 
                     broadcastAnswerUpdate();
-
 
 
                 } else if(responses.get(0).toString().toUpperCase().equals("REFUSE")) {
@@ -656,7 +656,7 @@ public class ClientProcessor implements Runnable {
 
                             // Remove the discarded card from the taker's hand
                             int slot = -1;
-                            PreparedStatement find = this.connection.prepareStatement("SELECT * FROM joueur WHERE reponse = 'TAKE' AND partie = ?");
+                            PreparedStatement find = this.connection.prepareStatement("SELECT * FROM joueur WHERE reponse NOT IN ('WAIT','REFUSE') AND partie = ?");
                             find.setInt(1, currentPartie);
                             ResultSet rFind = find.executeQuery();
                             if (rFind.next()) {
@@ -671,7 +671,7 @@ public class ClientProcessor implements Runnable {
                             rFind.close();
                             find.close();
                             if (slot > 0) {
-                                PreparedStatement up = this.connection.prepareStatement("UPDATE joueur SET carte" + slot + " = null WHERE reponse = 'TAKE' AND partie = ?");
+                                PreparedStatement up = this.connection.prepareStatement("UPDATE joueur SET carte" + slot + " = null WHERE reponse NOT IN ('WAIT','REFUSE') AND partie = ?");
                                 up.setInt(1, currentPartie);
                                 up.executeUpdate();
                                 up.close();
@@ -680,7 +680,7 @@ public class ClientProcessor implements Runnable {
                             if(nbCartesChien == 3) {
                                 dogDone = true;
                                 // Set next player after the taker
-                                PreparedStatement takerStmt = this.connection.prepareStatement("SELECT num FROM joueur WHERE reponse = 'TAKE' AND partie = ?");
+                                PreparedStatement takerStmt = this.connection.prepareStatement("SELECT num FROM joueur WHERE reponse NOT IN ('WAIT','REFUSE') AND partie = ?");
                                 takerStmt.setInt(1, currentPartie);
                                 ResultSet takerRs = takerStmt.executeQuery();
                                 if(takerRs.next()) {
@@ -978,7 +978,7 @@ public class ClientProcessor implements Runnable {
                 }
                 else if(responses.get(0).toString().toUpperCase().equals("WAITTOUR")) {
                     if(currentJoueurTour == -1) {
-                        String query = "SELECT num FROM joueur WHERE reponse = 'TAKE' AND partie = ?";
+                        String query = "SELECT num FROM joueur WHERE reponse NOT IN ('WAIT','REFUSE') AND partie = ?";
                         PreparedStatement ps = this.connection.prepareStatement(query);
                         ps.setInt(1, currentPartie);
                         ResultSet results = ps.executeQuery();

--- a/src/main/resources/sample/partie.fxml
+++ b/src/main/resources/sample/partie.fxml
@@ -94,21 +94,21 @@
          <!-- Middle spacer between left and actions -->
          <Region HBox.hgrow="ALWAYS" />
 
-         <!-- Action buttons & central card area -->
-         <VBox fx:id="contractBox" alignment="CENTER" spacing="10" visible="false"
-               style="-fx-background-color: rgba(0,0,0,0.5); -fx-background-radius: 5; -fx-padding: 10;">
-            <Button fx:id="petite" text="Petite" onAction="#choosePetite"
-                    style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
-            <Button fx:id="garde" text="Garde" onAction="#chooseGarde"
-                    style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
-            <Button fx:id="gardeContre" text="Garde contre" onAction="#chooseGardeContre"
-                    style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
-            <Button fx:id="gardeSans" text="Garde sans" onAction="#chooseGardeSans"
-                    style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
-            <Button fx:id="refuse" text="Refuser" onAction="#chooseRefuse"
-                    style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
-         </VBox>
+         <!-- Central action area -->
          <StackPane prefWidth="200" prefHeight="200">
+            <VBox fx:id="contractBox" alignment="CENTER" spacing="10" visible="false"
+                  style="-fx-background-color: rgba(0,0,0,0.5); -fx-background-radius: 5; -fx-padding: 10;">
+               <Button fx:id="petite" text="Petite" onAction="#choosePetite"
+                       style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
+               <Button fx:id="garde" text="Garde" onAction="#chooseGarde"
+                       style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
+               <Button fx:id="gardeContre" text="Garde contre" onAction="#chooseGardeContre"
+                       style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
+               <Button fx:id="gardeSans" text="Garde sans" onAction="#chooseGardeSans"
+                       style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
+               <Button fx:id="refuse" text="Refuser" onAction="#chooseRefuse"
+                       style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
+            </VBox>
             <HBox fx:id="boxTour" alignment="CENTER" spacing="10" />
             <HBox fx:id="boxChien" alignment="CENTER" spacing="20" />
             <ImageView fx:id="carteCenter" fitWidth="60" fitHeight="100" preserveRatio="true" />
@@ -145,6 +145,6 @@
              AnchorPane.bottomAnchor="10"
              AnchorPane.leftAnchor="20"
              AnchorPane.rightAnchor="20"
-             hgap="-80.0"
+             hgap="-20.0"
              alignment="CENTER"/>
 </AnchorPane>

--- a/src/main/resources/sample/partie.fxml
+++ b/src/main/resources/sample/partie.fxml
@@ -96,12 +96,12 @@
 
          <!-- Central action area -->
          <StackPane prefWidth="200" prefHeight="200">
-            <HBox fx:id="boxTour" alignment="CENTER" spacing="10" visible="false" />
+            <HBox fx:id="boxTour" alignment="CENTER" spacing="10" />
             <HBox fx:id="boxChien" alignment="CENTER" spacing="20" visible="false" />
             <ImageView fx:id="carteCenter" fitWidth="60" fitHeight="100" preserveRatio="true" visible="false" />
             <HBox fx:id="boxRois" alignment="CENTER" visible="false" />
             <Button fx:id="retrieveDog" text="Récupérer" onAction="#retrieveDogCards" visible="false" StackPane.alignment="BOTTOM_CENTER"/>
-            <VBox fx:id="contractBox" alignment="CENTER" spacing="10" visible="false"
+            <VBox fx:id="contractBox" alignment="CENTER" spacing="10" visible="false" managed="false"
                   style="-fx-background-color: rgba(0,0,0,0.5); -fx-background-radius: 5; -fx-padding: 10;">
                <Button fx:id="petite" text="Petite" onAction="#choosePetite"
                        style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />

--- a/src/main/resources/sample/partie.fxml
+++ b/src/main/resources/sample/partie.fxml
@@ -38,7 +38,7 @@
 
    <!-- Main content area -->
    <VBox AnchorPane.topAnchor="60"
-         AnchorPane.bottomAnchor="150"
+         AnchorPane.bottomAnchor="200"
          AnchorPane.leftAnchor="20"
          AnchorPane.rightAnchor="20"
          spacing="20">
@@ -96,6 +96,11 @@
 
          <!-- Central action area -->
          <StackPane prefWidth="200" prefHeight="200">
+            <HBox fx:id="boxTour" alignment="CENTER" spacing="10" visible="false" />
+            <HBox fx:id="boxChien" alignment="CENTER" spacing="20" visible="false" />
+            <ImageView fx:id="carteCenter" fitWidth="60" fitHeight="100" preserveRatio="true" visible="false" />
+            <HBox fx:id="boxRois" alignment="CENTER" visible="false" />
+            <Button fx:id="retrieveDog" text="Récupérer" onAction="#retrieveDogCards" visible="false" StackPane.alignment="BOTTOM_CENTER"/>
             <VBox fx:id="contractBox" alignment="CENTER" spacing="10" visible="false"
                   style="-fx-background-color: rgba(0,0,0,0.5); -fx-background-radius: 5; -fx-padding: 10;">
                <Button fx:id="petite" text="Petite" onAction="#choosePetite"
@@ -109,11 +114,6 @@
                <Button fx:id="refuse" text="Refuser" onAction="#chooseRefuse"
                        style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
             </VBox>
-            <HBox fx:id="boxTour" alignment="CENTER" spacing="10" />
-            <HBox fx:id="boxChien" alignment="CENTER" spacing="20" />
-            <ImageView fx:id="carteCenter" fitWidth="60" fitHeight="100" preserveRatio="true" />
-            <HBox fx:id="boxRois" alignment="CENTER" />
-            <Button fx:id="retrieveDog" text="Récupérer" onAction="#retrieveDogCards" visible="false" StackPane.alignment="BOTTOM_CENTER"/>
          </StackPane>
 
          <!-- Middle spacer between actions and right player -->
@@ -136,7 +136,7 @@
 
    <!-- Self score at bottom center -->
    <Label fx:id="scoreSelf" alignment="CENTER" style="-fx-text-fill: white;"
-          AnchorPane.bottomAnchor="130"
+          AnchorPane.bottomAnchor="180"
           AnchorPane.leftAnchor="0"
           AnchorPane.rightAnchor="0" />
 
@@ -145,6 +145,6 @@
              AnchorPane.bottomAnchor="10"
              AnchorPane.leftAnchor="20"
              AnchorPane.rightAnchor="20"
-             hgap="-20.0"
+             hgap="-80.0"
              alignment="CENTER"/>
 </AnchorPane>

--- a/src/main/resources/sample/partie.fxml
+++ b/src/main/resources/sample/partie.fxml
@@ -57,13 +57,21 @@
             </ImageView>
          </VBox>
          <Region HBox.hgrow="ALWAYS" />
-         <HBox fx:id="teamScoreBox" alignment="CENTER" spacing="10.0" visible="false" style="-fx-background-color: rgba(0,0,0,0.5); -fx-padding: 5; -fx-background-radius: 5;">
-              <children>
-                  <Label fx:id="attackScoreLabel" style="-fx-text-fill: #6c0303; -fx-font-size: 1em; -fx-font-weight: bold;" />
-                  <Label text="|" style="-fx-text-fill: white; -fx-font-size: 1em; -fx-font-weight: bold;" />
-                  <Label fx:id="defenseScoreLabel" style="-fx-text-fill: #2c2c85; -fx-font-size: 1em; -fx-font-weight: bold;" />
-              </children>
-          </HBox>
+        <VBox fx:id="teamScoreBox" alignment="CENTER" spacing="5" visible="true"
+              style="-fx-background-color: rgba(0,0,0,0.5); -fx-padding: 5; -fx-background-radius: 5;">
+            <children>
+                <Label text="Score:" style="-fx-text-fill: white; -fx-font-size: 1em; -fx-font-weight: bold;" />
+                <HBox alignment="CENTER" spacing="10">
+                    <children>
+                        <Label fx:id="attackScoreLabel" text="?"
+                               style="-fx-text-fill: #6c0303; -fx-font-size: 1em; -fx-font-weight: bold;" />
+                        <Label text="|" style="-fx-text-fill: white; -fx-font-size: 1em; -fx-font-weight: bold;" />
+                        <Label fx:id="defenseScoreLabel" text="?"
+                               style="-fx-text-fill: #2c2c85; -fx-font-size: 1em; -fx-font-weight: bold;" />
+                    </children>
+                </HBox>
+            </children>
+        </VBox>
          <Region HBox.hgrow="ALWAYS" />
          <VBox alignment="CENTER" spacing="5">
             <Label fx:id="labelTopRight" style="-fx-text-fill: white; -fx-font-size: 1em; -fx-font-weight: bold;" />
@@ -133,12 +141,6 @@
       </HBox>
 
    </VBox>
-
-   <!-- Self score at bottom center -->
-   <Label fx:id="scoreSelf" alignment="CENTER" style="-fx-text-fill: white;"
-          AnchorPane.bottomAnchor="180"
-          AnchorPane.leftAnchor="0"
-          AnchorPane.rightAnchor="0" />
 
    <!-- Player hand or dynamic cards -->
    <FlowPane fx:id="main"

--- a/src/main/resources/sample/partie.fxml
+++ b/src/main/resources/sample/partie.fxml
@@ -95,7 +95,19 @@
          <Region HBox.hgrow="ALWAYS" />
 
          <!-- Action buttons & central card area -->
-         <Button fx:id="take" text="Prendre le chien" onAction="#playWithDog" visible="false" />
+         <VBox fx:id="contractBox" alignment="CENTER" spacing="10" visible="false"
+               style="-fx-background-color: rgba(0,0,0,0.5); -fx-background-radius: 5; -fx-padding: 10;">
+            <Button fx:id="petite" text="Petite" onAction="#choosePetite"
+                    style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
+            <Button fx:id="garde" text="Garde" onAction="#chooseGarde"
+                    style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
+            <Button fx:id="gardeContre" text="Garde contre" onAction="#chooseGardeContre"
+                    style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
+            <Button fx:id="gardeSans" text="Garde sans" onAction="#chooseGardeSans"
+                    style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
+            <Button fx:id="refuse" text="Refuser" onAction="#chooseRefuse"
+                    style="-fx-background-color: rgba(0,0,0,0.5); -fx-text-fill: white; -fx-background-radius: 5;" />
+         </VBox>
          <StackPane prefWidth="200" prefHeight="200">
             <HBox fx:id="boxTour" alignment="CENTER" spacing="10" />
             <HBox fx:id="boxChien" alignment="CENTER" spacing="20" />
@@ -103,7 +115,6 @@
             <HBox fx:id="boxRois" alignment="CENTER" />
             <Button fx:id="retrieveDog" text="Récupérer" onAction="#retrieveDogCards" visible="false" StackPane.alignment="BOTTOM_CENTER"/>
          </StackPane>
-         <Button fx:id="refuse" text="Refuser le chien" onAction="#playWithoutDog" visible="false" />
 
          <!-- Middle spacer between actions and right player -->
          <Region HBox.hgrow="ALWAYS" />


### PR DESCRIPTION
## Summary
- replace take/refuse prompts with vertically stacked contract buttons styled to match the UI and tighten hand card spacing
- enable pointer hover effects across king call and dog selection while preventing bouts and kings from being discarded
- store chosen contract type server-side for later scoring calculations

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688f8484f94c832ebaf199fcfd2ae518